### PR TITLE
Avoid recommending Encode::encode_utf8

### DIFF
--- a/lib/Sys/Binmode.pm
+++ b/lib/Sys/Binmode.pm
@@ -161,7 +161,7 @@ C<print()>: encode your string before you give it to the OS.
     use utf8;
     use Encode;
 
-    mkdir encode_utf8("épée");
+    mkdir encode("UTF-8", "épée");
 
 This is what your code should look like, regardless of Sys::Binmode;
 the omitted encoding step was a bug that Perl’s own abstraction-violation


### PR DESCRIPTION
While it's unlikely to cause problems with normal strings such as those the user would provide under `use utf8`, Encode's `encode_utf8` and `decode_utf8` should be discouraged as they simply assume the internal stored bytes are appropriate to output as UTF-8, or vice versa.